### PR TITLE
fix: make staging build work without OpenAI key

### DIFF
--- a/app/api/interview-generator/route.ts
+++ b/app/api/interview-generator/route.ts
@@ -4,9 +4,11 @@ import { masterPrompt } from './prompts/masterPrompt';
 
 export const runtime = 'edge';
 
-const openai = new OpenAI({
-    apiKey: process.env.OPENAI_API_KEY,
-});
+function getOpenAIClient() {
+    const apiKey = process.env.OPENAI_API_KEY;
+
+    return apiKey ? new OpenAI({ apiKey }) : null;
+}
 
 // Add type interface at the top of the file
 interface InterviewInputs {
@@ -65,6 +67,17 @@ export async function POST(request: Request) {
                 }),
                 {
                     status: 400,
+                    headers: { 'Content-Type': 'application/json' }
+                }
+            );
+        }
+
+        const openai = getOpenAIClient();
+        if (!openai) {
+            return new Response(
+                JSON.stringify({ error: 'Interview generator is unavailable' }),
+                {
+                    status: 503,
                     headers: { 'Content-Type': 'application/json' }
                 }
             );


### PR DESCRIPTION
Fixes the staging build failure caused by creating the OpenAI client during Next.js module evaluation.

The interview route now creates the client only for a request and returns HTTP 503 when the staging environment intentionally has no OpenAI credential.

Validated with `OPENAI_API_KEY=`: `pnpm build` passed and a valid POST returned 503 without triggering role enrichment.