### PR TITLE
fix: harden staging container runtime

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.next
+.brain
+node_modules
+coverage
+storybook-static
+.env*
+*.pem
+npm-debug.log*
+pnpm-debug.log*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:22.11.0-bookworm-slim
+
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PUPPETEER_SKIP_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/chromium
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends chromium dumb-init \
+    && rm -rf /var/lib/apt/lists/* \
+    && corepack enable \
+    && corepack prepare pnpm@9.15.9 --activate
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+COPY . ./
+RUN pnpm run build \
+    && pnpm prune --prod \
+    && groupadd --system --gid 10001 app \
+    && useradd --system --uid 10001 --gid app --home-dir /app app \
+    && chown --recursive app:app /app
+
+USER app
+
+EXPOSE 3000
+
+ENTRYPOINT ["dumb-init", "--"]
+CMD ["pnpm", "start"]


### PR DESCRIPTION
Adds a source-controlled production Dockerfile for the staging image. The runtime now uses an unprivileged UID, disables Puppeteer browser downloads, uses system Chromium, and excludes local secrets from the build context.\n\nValidation: Dockerfile and build context reviewed; local Docker daemon unavailable for build execution. The staging Coolify deployment will be the integration receipt.