### PR TITLE
fix: install pnpm without corepack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,7 @@ ENV NEXT_TELEMETRY_DISABLED=1 \
 RUN apt-get update \
     && apt-get install --yes --no-install-recommends chromium dumb-init \
     && rm -rf /var/lib/apt/lists/* \
-    && corepack enable \
-    && corepack prepare pnpm@9.15.9 --activate
+    && npm install --global pnpm@9.15.9
 
 WORKDIR /app
 


### PR DESCRIPTION
Uses the pinned pnpm release directly rather than Corepack, whose signature metadata is incompatible with the pinned Node image. This unblocks the hardened staging container build.