### PR TITLE
fix: skip lifecycle scripts when pruning runtime dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN pnpm install --frozen-lockfile
 
 COPY . ./
 RUN pnpm run build \
-    && pnpm prune --prod \
+    && pnpm prune --prod --ignore-scripts \
     && groupadd --system --gid 10001 app \
     && useradd --system --uid 10001 --gid app --home-dir /app app \
     && chown --recursive app:app /app


### PR DESCRIPTION
Fixes the staging Docker image build: pnpm prune removes Husky before its prepare hook can run. Uses --ignore-scripts only during production pruning. The authoritative validation is the Singularity-One Coolify build; local Docker is unavailable on this Mac.